### PR TITLE
Fix of security issues

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,9 +293,8 @@ impl Contract {
     }
 
     fn abort_if_not_owner(&self) {
-        if env::signer_account_id() != env::current_account_id()
-            && env::signer_account_id() != self.owner_id
-            && env::signer_account_id() != env::predecessor_account_id()
+        if env::predecessor_account_id() != env::current_account_id()
+            && env::predecessor_account_id() != self.owner_id
         {
             env::panic_str("This method might be called only by owner account")
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,6 @@ impl Contract {
         if env::signer_account_id() != env::current_account_id()
             && env::signer_account_id() != self.owner_id
             && env::signer_account_id() != env::predecessor_account_id()
-        // ?
         {
             env::panic_str("This method might be called only by owner account")
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ impl Contract {
 
     pub fn upgrade_name_symbol(&mut self, name: String, symbol: String) {
         self.abort_if_not_owner();
-        let metadata = self.metadata.take();
+        let metadata = self.metadata.get();
         if let Some(mut metadata) = metadata {
             metadata.name = name;
             metadata.symbol = symbol;
@@ -112,7 +112,7 @@ impl Contract {
 
     pub fn upgrade_icon(&mut self, data: String) {
         self.abort_if_not_owner();
-        let metadata = self.metadata.take();
+        let metadata = self.metadata.get();
         if let Some(mut metadata) = metadata {
             metadata.icon = Some(data);
             self.metadata.replace(&metadata);
@@ -249,7 +249,7 @@ impl Contract {
      */
     pub fn name(&mut self) -> String {
         self.abort_if_pause();
-        let metadata = self.metadata.take();
+        let metadata = self.metadata.get();
         metadata.expect("Unable to get decimals").name
     }
 
@@ -258,7 +258,7 @@ impl Contract {
      */
     pub fn symbol(&mut self) -> String {
         self.abort_if_pause();
-        let metadata = self.metadata.take();
+        let metadata = self.metadata.get();
         metadata.expect("Unable to get decimals").symbol
     }
 
@@ -267,7 +267,7 @@ impl Contract {
      */
     pub fn decimals(&mut self) -> u8 {
         self.abort_if_pause();
-        let metadata = self.metadata.take();
+        let metadata = self.metadata.get();
         metadata.expect("Unable to get decimals").decimals
     }
 
@@ -296,6 +296,7 @@ impl Contract {
         if env::signer_account_id() != env::current_account_id()
             && env::signer_account_id() != self.owner_id
             && env::signer_account_id() != env::predecessor_account_id()
+        // ?
         {
             env::panic_str("This method might be called only by owner account")
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,8 @@ impl Contract {
 
     pub fn set_owner(&mut self, owner_id: AccountId) {
         self.abort_if_not_owner();
-        self.owner_id = owner_id;
+        self.owner_id =
+            AccountId::try_from(owner_id).expect("Couldn't validate new owner's address");
     }
 
     pub fn upgrade_icon(&mut self, data: String) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,8 +107,7 @@ impl Contract {
 
     pub fn set_owner(&mut self, owner_id: AccountId) {
         self.abort_if_not_owner();
-        self.owner_id =
-            AccountId::try_from(owner_id).expect("Couldn't validate new owner's address");
+        self.owner_id = owner_id;
     }
 
     pub fn upgrade_icon(&mut self, data: String) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,6 +295,7 @@ impl Contract {
     fn abort_if_not_owner(&self) {
         if env::signer_account_id() != env::current_account_id()
             && env::signer_account_id() != self.owner_id
+            && env::signer_account_id() != env::predecessor_account_id()
         {
             env::panic_str("This method might be called only by owner account")
         }


### PR DESCRIPTION
Problems: 
1. Owner check can pass even as predecessor is another contract
2. Metadata is removed from storage in upgrade of metadata fields methods

Solutions:
1. Owner check won`t allow further actions if predecessor is not an owner
2. Receive metadata without removing it from storage