### PR TITLE
Set sender in ft_transfer method as predecessor account

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,7 +352,7 @@ impl FungibleTokenCore for Contract {
     #[payable]
     fn ft_transfer(&mut self, receiver_id: AccountId, amount: U128, memo: Option<String>) {
         self.abort_if_pause();
-        let sender_id = AccountId::try_from(env::signer_account_id())
+        let sender_id = AccountId::try_from(env::predecessor_account_id())
             .expect("Couldn't validate sender address");
         match self.get_blacklist_status(&sender_id) {
             BlackListStatus::Allowable => {


### PR DESCRIPTION
Problem

- The contract implements a blacklist functionality, which prevents users labeled as blacklisted from using certain functions. The validation mechanism relies on checking if the account which signed the transaction is present on that list. In such a scenario, the blacklist validation will pass. However, the tokens will be sent from blacklisted account ID

Solution

- Set sender in ft_transfer method as predecessor account, so blacklisted account couldn't use another account to transfer