### PR TITLE
Remove check for contract initialize in `new` function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,6 @@ impl Contract {
     // the given fungible token metadata.
     #[init]
     pub fn new(owner_id: AccountId, total_supply: U128, metadata: FungibleTokenMetadata) -> Self {
-        assert!(!env::state_exists(), "Already initialized");
         metadata.assert_valid();
         let mut this = Self {
             owner_id: owner_id.clone(),


### PR DESCRIPTION
Problem

- USDTGold smart contract implements a storage initializing function called new. Init macro is responsible for ensuring that the storage state was not initialized and will panic otherwise. The new function implements a manual verification of whether a state exists via the assert! macro. This is a redundant code, which results in the function executing the same verification twice

Solution

- Remove manual verification of contract existence