### PR TITLE
Remove owner verification in view contract status

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,7 +240,6 @@ impl Contract {
     }
 
     pub fn contract_status(&self) -> ContractStatus {
-        self.abort_if_not_owner();
         self.status
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,6 +467,14 @@ mod tests {
     }
 
     #[test]
+    fn test_contract_status() {
+        let context = get_context(accounts(1));
+        testing_env!(context.build());
+        let contract = Contract::new_default_meta(accounts(2).into(), TOTAL_SUPPLY.into());
+        assert_eq!(contract.contract_status(), ContractStatus::Working);
+    }
+
+    #[test]
     fn test_transfer() {
         let mut context = get_context(accounts(2));
         testing_env!(context.build());


### PR DESCRIPTION
Problem

- contract_status function is restricted so that only an owner can call it, which may not be necessary. Allowing all users to call the contract_status function might prevent function calls that will trigger errors. 

Solution

- Remove owner check, so all users can view contract status