### PR TITLE
Check contract status before pausing or resuming it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,14 +229,14 @@ impl Contract {
 
     // If we have to pause contract
     pub fn pause(&mut self) {
-        assert_eq!(self.status, ContractStatus::Paused);
+        assert_eq!(self.status, ContractStatus::Working);
         self.abort_if_not_owner();
         self.status = ContractStatus::Paused;
     }
 
     // If we have to resume contract
     pub fn resume(&mut self) {
-        assert_eq!(self.status, ContractStatus::Working);
+        assert_eq!(self.status, ContractStatus::Paused);
         self.abort_if_not_owner();
         self.status = ContractStatus::Working;
     }
@@ -467,6 +467,37 @@ mod tests {
         let context = get_context(accounts(1));
         testing_env!(context.build());
         let _contract = Contract::default();
+    }
+
+    #[test]
+    fn test_contract_status_change() {
+        let context = get_context(accounts(1));
+        testing_env!(context.build());
+        let mut contract = Contract::new_default_meta(accounts(1).into(), TOTAL_SUPPLY.into());
+        contract.pause();
+        assert_eq!(contract.contract_status(), ContractStatus::Paused);
+        contract.resume();
+        assert_eq!(contract.contract_status(), ContractStatus::Working);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_contract_status_pause() {
+        let context = get_context(accounts(1));
+        testing_env!(context.build());
+        let mut contract = Contract::new_default_meta(accounts(1).into(), TOTAL_SUPPLY.into());
+        contract.pause();
+        assert_eq!(contract.contract_status(), ContractStatus::Paused);
+        contract.pause();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_contract_status_resume() {
+        let context = get_context(accounts(1));
+        testing_env!(context.build());
+        let mut contract = Contract::new_default_meta(accounts(1).into(), TOTAL_SUPPLY.into());
+        contract.resume();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,37 +470,6 @@ mod tests {
     }
 
     #[test]
-    fn test_contract_status_change() {
-        let context = get_context(accounts(1));
-        testing_env!(context.build());
-        let mut contract = Contract::new_default_meta(accounts(1).into(), TOTAL_SUPPLY.into());
-        contract.pause();
-        assert_eq!(contract.contract_status(), ContractStatus::Paused);
-        contract.resume();
-        assert_eq!(contract.contract_status(), ContractStatus::Working);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_contract_status_pause() {
-        let context = get_context(accounts(1));
-        testing_env!(context.build());
-        let mut contract = Contract::new_default_meta(accounts(1).into(), TOTAL_SUPPLY.into());
-        contract.pause();
-        assert_eq!(contract.contract_status(), ContractStatus::Paused);
-        contract.pause();
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_contract_status_resume() {
-        let context = get_context(accounts(1));
-        testing_env!(context.build());
-        let mut contract = Contract::new_default_meta(accounts(1).into(), TOTAL_SUPPLY.into());
-        contract.resume();
-    }
-
-    #[test]
     fn test_transfer() {
         let mut context = get_context(accounts(2));
         testing_env!(context.build());
@@ -667,5 +636,25 @@ mod tests {
             let _ = contract.ft_total_supply();
         });
         assert!(result.is_err());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_contract_status_pause() {
+        let context = get_context(accounts(1));
+        testing_env!(context.build());
+        let mut contract = Contract::new_default_meta(accounts(1).into(), TOTAL_SUPPLY.into());
+        contract.pause();
+        assert_eq!(contract.contract_status(), ContractStatus::Paused);
+        contract.pause();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_contract_status_resume() {
+        let context = get_context(accounts(1));
+        testing_env!(context.build());
+        let mut contract = Contract::new_default_meta(accounts(1).into(), TOTAL_SUPPLY.into());
+        contract.resume();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,12 +229,14 @@ impl Contract {
 
     // If we have to pause contract
     pub fn pause(&mut self) {
+        assert_eq!(self.status, ContractStatus::Paused);
         self.abort_if_not_owner();
         self.status = ContractStatus::Paused;
     }
 
     // If we have to resume contract
     pub fn resume(&mut self) {
+        assert_eq!(self.status, ContractStatus::Working);
         self.abort_if_not_owner();
         self.status = ContractStatus::Working;
     }


### PR DESCRIPTION
Problem

- Both pause and resume functions can be called multiple times regardless of the contract’s status, which requires the contract to
execute the abort_if_not_owner function each time along with assigning the value to the status storage variable. If the contract is paused, subsequent calls to the pause function do not change anything but still cost gas.

Solution

- Check for contract status in resume/pause contract before owner check and assigning the value to the status storage variable