### PR TITLE
Redeem tokens using owner account

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ impl Contract {
     // if the balance must be enough to cover the redeem
     // or the call will fail.
     pub fn redeem(&mut self, amount: U128) {
-        self.burn(&env::current_account_id(), amount)
+        self.burn(&self.owner_id.clone(), amount)
     }
 
     // Redeem tokens (burn).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,8 @@ impl Contract {
     // Issue a new amount of tokens
     // these tokens are deposited into the owner address
     pub fn issue(&mut self, amount: U128) -> Balance {
-        self.mint(&env::current_account_id(), amount)
+        self.abort_if_not_owner();
+        self.mint(&self.owner_id.clone(), amount)
     }
 
     // Creates `amount` tokens and assigns them to `account`, increasing
@@ -198,6 +199,7 @@ impl Contract {
     // if the balance must be enough to cover the redeem
     // or the call will fail.
     pub fn redeem(&mut self, amount: U128) {
+        self.abort_if_not_owner();
         self.burn(&self.owner_id.clone(), amount)
     }
 
@@ -571,13 +573,13 @@ mod tests {
         testing_env!(context
             .storage_usage(env::storage_usage())
             .attached_deposit(contract.storage_balance_bounds().min.into())
-            .predecessor_account_id(accounts(1))
+            .predecessor_account_id(accounts(2))
             .current_account_id(accounts(1))
-            .signer_account_id(accounts(1))
+            .signer_account_id(accounts(2))
             .build());
 
         let previous_total_supply = contract.ft_total_supply().0;
-        let previous_balance = contract.ft_balance_of(accounts(1)).0;
+        let previous_balance = contract.ft_balance_of(accounts(2)).0;
         let reissuance_balance: Balance = 1_234_567_891;
         contract.issue(U128::from(reissuance_balance));
         assert_eq!(
@@ -586,7 +588,7 @@ mod tests {
         );
         assert_eq!(
             previous_balance + reissuance_balance,
-            contract.ft_balance_of(accounts(1)).0
+            contract.ft_balance_of(accounts(2)).0
         );
     }
 


### PR DESCRIPTION
Problem

- USDTGold smart contract implements a redeem function that internally uses the burn function to decrease a token’s total supply by subtracting it from the contract owner’s account. However, it uses an env::current_account_id function. It is possible to deploy the contract and set the owner ID to an arbitrarily chosen address, which does not need to be an account ID of the contract itself. In such a scenario, calling the redeem function will trigger an error, as the account ID of that contract may have no balance.

Solution

- Use owner account id in redeem function instead of current account id